### PR TITLE
Phsen pco2w sami bits updates

### DIFF
--- a/calibration/PCO2WC/CGINS-PCO2WC-C0107__20211228.csv
+++ b/calibration/PCO2WC/CGINS-PCO2WC-C0107__20211228.csv
@@ -7,5 +7,5 @@ C0107,CC_ea434,19706,constant
 C0107,CC_ea620,34,constant
 C0107,CC_eb434,3073,constant
 C0107,CC_eb620,44327,constant
-C0107,CC_sami_bits,12,
+C0107,CC_sami_bits,14,
 C0107,CC_cal_range,"[0,0]",

--- a/calibration/PCO2WC/CGINS-PCO2WC-C0108__20220103.csv
+++ b/calibration/PCO2WC/CGINS-PCO2WC-C0108__20220103.csv
@@ -7,5 +7,5 @@ C0108,CC_ea434,19706,constant
 C0108,CC_ea620,34,constant
 C0108,CC_eb434,3073,constant
 C0108,CC_eb620,44327,constant
-C0108,CC_sami_bits,12,
+C0108,CC_sami_bits,14,
 C0108,CC_cal_range,"[0,0]",

--- a/calibration/PCO2WC/CGINS-PCO2WC-C0120__20211214.csv
+++ b/calibration/PCO2WC/CGINS-PCO2WC-C0120__20211214.csv
@@ -7,5 +7,5 @@ C0120,CC_ea434,19706,constant
 C0120,CC_ea620,34,constant
 C0120,CC_eb434,3073,constant
 C0120,CC_eb620,44327,constant
-C0120,CC_sami_bits,12,
+C0120,CC_sami_bits,14,
 C0120,CC_cal_range,"[0,0]",

--- a/calibration/PCO2WC/CGINS-PCO2WC-C0140__20220131.csv
+++ b/calibration/PCO2WC/CGINS-PCO2WC-C0140__20220131.csv
@@ -7,5 +7,5 @@ C0140,CC_ea434,19706,constant
 C0140,CC_ea620,34,constant
 C0140,CC_eb434,3073,constant
 C0140,CC_eb620,44327,constant
-C0140,CC_sami_bits,12,
+C0140,CC_sami_bits,14,
 C0140,CC_cal_range,"[0,0]",

--- a/calibration/PHSENE/CGINS-PHSENE-P0172__20220127.csv
+++ b/calibration/PHSENE/CGINS-PHSENE-P0172__20220127.csv
@@ -6,4 +6,4 @@ P0172,CC_eb578,38676.0,
 P0172,CC_ind_off,0,
 P0172,CC_ind_slp,1,
 P0172,CC_psal,35,Constant
-P0172,CC_sami_bits,12,
+P0172,CC_sami_bits,14,

--- a/calibration/PHSENE/CGINS-PHSENE-P0177__20220127.csv
+++ b/calibration/PHSENE/CGINS-PHSENE-P0177__20220127.csv
@@ -6,4 +6,4 @@ P0177,CC_eb578,38676.0,
 P0177,CC_ind_off,0,
 P0177,CC_ind_slp,1,
 P0177,CC_psal,35,Constant
-P0177,CC_sami_bits,12,
+P0177,CC_sami_bits,14,

--- a/calibration/PHSENE/CGINS-PHSENE-P0178__20220127.csv
+++ b/calibration/PHSENE/CGINS-PHSENE-P0178__20220127.csv
@@ -6,4 +6,4 @@ P0178,CC_eb578,38676.0,
 P0178,CC_ind_off,0,
 P0178,CC_ind_slp,1,
 P0178,CC_psal,35,Constant
-P0178,CC_sami_bits,12,
+P0178,CC_sami_bits,14,


### PR DESCRIPTION
PCO2W and PHSEN CC_sami_bits values updated to 14 where units have been upgraded to 14-bit Rev K boards. Board updates are captured in this Google Sheet: https://docs.google.com/spreadsheets/d/1u74ZBrWE5pZw9_auFhBxFku91GOYXml9geBjmnQ8cLw/edit#gid=1082765693