### PR TITLE
added AUV NBOSI CT sensor

### DIFF
--- a/bulk/sensor_vocab.csv
+++ b/bulk/sensor_vocab.csv
@@ -143,6 +143,7 @@ Underwater Digital Still Camera: CAMDS Series C,Kongsberg Underwater Technology 
 3-Wavelength Flourometer for AUV: FLORT Series N,WET Labs,BBFL2HYD
 Dissolved Oxygen for AUV: DOSTA Series N,Aanderaa,Optode 4330
 CTD for AUV: CTD Series N,Sea-Bird Electronics,SBE AUV Payload CTD
+CTD for AUV: CTDAV Series N,NBOSI,NBOSI CT Sensor
 Nitrate for AUV: NUTNR Series N,Satlantic,SUNA
 ADCP for AUV: ADCPA series N,Teledyne RDI,Explorer DVL 600 kHz
 Photosynthetically Available Radiation for AUV: PARAD Series N,Biospherical Instruments,QSP-2155


### PR DESCRIPTION
added NBOSI CT sensor for AUV (see slack thread from yesterday for implementation in vocab.csv).  VOCAB_REFDES_2024-01-17.xlsx attached for reference - info highlighted at bottom of file (under CP16MOAS).

[VOCAB_REFDES_2024-01-17.xlsx](https://github.com/WHOIGit/ooicgsn-asset-management/files/13978640/VOCAB_REFDES_2024-01-17.xlsx)
