### PR TITLE
MAB-specific cal csvs

### DIFF
--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01033__20231125.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01033__20231125.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1033,CC_scale_factor1,0.45,constant
+1033,CC_scale_factor2,0.45,constant
+1033,CC_scale_factor3,0.45,constant
+1033,CC_scale_factor4,0.45,constant

--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01035__20231202.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01035__20231202.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1035,CC_scale_factor1,0.45,constant
+1035,CC_scale_factor2,0.45,constant
+1035,CC_scale_factor3,0.45,constant
+1035,CC_scale_factor4,0.45,constant

--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01036__20231202.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01036__20231202.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1036,CC_scale_factor1,0.45,constant
+1036,CC_scale_factor2,0.45,constant
+1036,CC_scale_factor3,0.45,constant
+1036,CC_scale_factor4,0.45,constant

--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01040__20231219.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01040__20231219.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1040,CC_scale_factor1,0.45,constant
+1040,CC_scale_factor2,0.45,constant
+1040,CC_scale_factor3,0.45,constant
+1040,CC_scale_factor4,0.45,constant

--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01041__20231219.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01041__20231219.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1041,CC_scale_factor1,0.45,constant
+1041,CC_scale_factor2,0.45,constant
+1041,CC_scale_factor3,0.45,constant
+1041,CC_scale_factor4,0.45,constant

--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01042__20231219.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01042__20231219.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1042,CC_scale_factor1,0.45,constant
+1042,CC_scale_factor2,0.45,constant
+1042,CC_scale_factor3,0.45,constant
+1042,CC_scale_factor4,0.45,constant

--- a/calibration/ADCPTQ/CGINS-ADCPTQ-01043__20231219.csv
+++ b/calibration/ADCPTQ/CGINS-ADCPTQ-01043__20231219.csv
@@ -1,0 +1,5 @@
+serial,name,value,notes
+1043,CC_scale_factor1,0.45,constant
+1043,CC_scale_factor2,0.45,constant
+1043,CC_scale_factor3,0.45,constant
+1043,CC_scale_factor4,0.45,constant

--- a/calibration/FLORTD/CGINS-FLORTD-01214__20231030.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01214__20231030.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1214,CC_angular_resolution,1.076,Constant; source_file FLORT-D_BBFL2W_SN_1214_Calibration_Files_2023-10-30.zip > BBFL2W-1214.dev
+1214,CC_dark_counts_cdom,34,
+1214,CC_dark_counts_chlorophyll_a,50,
+1214,CC_dark_counts_volume_scatter,50,
+1214,CC_depolarization_ratio,0.039,Constant
+1214,CC_measurement_wavelength,700,Constant
+1214,CC_scale_factor_cdom,9.077E-02,
+1214,CC_scale_factor_chlorophyll_a,1.210E-02,
+1214,CC_scale_factor_volume_scatter,1.982E-06,
+1214,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01215__20231106.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01215__20231106.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1215,CC_angular_resolution,1.076,Constant; source_file FLORT-D_BBFL2W_SN_1215_Calibration_Files_2023-11-06.zip > BBFL2W-1215.dev
+1215,CC_dark_counts_cdom,47,
+1215,CC_dark_counts_chlorophyll_a,42,
+1215,CC_dark_counts_volume_scatter,46,
+1215,CC_depolarization_ratio,0.039,Constant
+1215,CC_measurement_wavelength,700,Constant
+1215,CC_scale_factor_cdom,8.983E-02,
+1215,CC_scale_factor_chlorophyll_a,1.207E-02,
+1215,CC_scale_factor_volume_scatter,1.874E-06,
+1215,CC_scattering_angle,124,Constant

--- a/calibration/FLORTD/CGINS-FLORTD-01216__20231113.csv
+++ b/calibration/FLORTD/CGINS-FLORTD-01216__20231113.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+1216,CC_angular_resolution,1.076,Constant; source_file FLORT-D_BBFL2W_SN_1216_Calibration_Files_2023-11-13.zip > BBFL2W-1216.dev
+1216,CC_dark_counts_cdom,50,
+1216,CC_dark_counts_chlorophyll_a,50,
+1216,CC_dark_counts_volume_scatter,53.275,
+1216,CC_depolarization_ratio,0.039,Constant
+1216,CC_measurement_wavelength,700,Constant
+1216,CC_scale_factor_cdom,9.083E-02,
+1216,CC_scale_factor_chlorophyll_a,1.259E-02,
+1216,CC_scale_factor_volume_scatter,1.755E-06,
+1216,CC_scattering_angle,124,Constant

--- a/calibration/TURBDX/CGINS-TURBDX-01106__20231103.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01106__20231103.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1106,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1106_Calibration_Files_NTU_2023-11-03.zip > BBFL2W-1106.dev
+1106,CC_scale_factor_turbd,6.247E-02,
+1106,CC_cal_range,"[0,250]",

--- a/calibration/TURBDX/CGINS-TURBDX-01213__20240202.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01213__20240202.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1213,CC_dark_counts_turbd,60,source_file FLORT-D_BBFL2W_SN_1213_NTU_Characterization_2024-02-02.pdf
+1213,CC_scale_factor_turbd,8.53E-04,
+1213,CC_cal_range,"[0,3]",

--- a/calibration/TURBDX/CGINS-TURBDX-01214__20240202.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01214__20240202.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1214,CC_dark_counts_turbd,60,source_file FLORT-D_BBFL2W_SN_1214_NTU_Characterization_2024-02-02.pdf
+1214,CC_scale_factor_turbd,7.83E-04,
+1214,CC_cal_range,"[0,3]",

--- a/calibration/TURBDX/CGINS-TURBDX-01215__20240202.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01215__20240202.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1215,CC_dark_counts_turbd,60,source_file FLORT-D_BBFL2W_SN_1215_NTU_Characterization_2024-02-02.pdf
+1215,CC_scale_factor_turbd,8.04E-04,
+1215,CC_cal_range,"[0,3]",

--- a/calibration/TURBDX/CGINS-TURBDX-01216__20240202.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01216__20240202.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1216,CC_dark_counts_turbd,53,source_file FLORT-D_BBFL2W_SN_1216_NTU_Characterization_2024-02-02.pdf
+1216,CC_scale_factor_turbd,7.64E-04,
+1216,CC_cal_range,"[0,3]",

--- a/calibration/TURBDX/CGINS-TURBDX-01218__20231024.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01218__20231024.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1218,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1218_Calibration_Files_2022-01-13.zip > BBFL2W-1218.dev
+1218,CC_scale_factor_turbd,6.055E-02,
+1218,CC_cal_range,"[0,250]",

--- a/calibration/TURBDX/CGINS-TURBDX-01218__20231024.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01218__20231024.csv
@@ -1,4 +1,4 @@
 serial,name,value,notes
-1218,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1218_Calibration_Files_2022-01-13.zip > BBFL2W-1218.dev
+1218,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1218_Calibration_Files_NTU_2023-10-24.zip > BBFL2W-1218.dev
 1218,CC_scale_factor_turbd,6.055E-02,
 1218,CC_cal_range,"[0,250]",

--- a/calibration/TURBDX/CGINS-TURBDX-01295__20231128.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01295__20231128.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1295,CC_dark_counts_turbd,56,source_file FLORT-D_BBFL2W_SN_1295_Calibration_Files_2022-09-09.zip > BBFL2W-1295.dev
+1295,CC_scale_factor_turbd,0.0493,
+1295,CC_cal_range,"[0,200]",

--- a/calibration/TURBDX/CGINS-TURBDX-01295__20231128.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01295__20231128.csv
@@ -1,4 +1,4 @@
 serial,name,value,notes
-1295,CC_dark_counts_turbd,56,source_file FLORT-D_BBFL2W_SN_1295_Calibration_Files_2022-09-09.zip > BBFL2W-1295.dev
+1295,CC_dark_counts_turbd,56,source_file FLORT-D_BBFL2W_SN_1295_Calibration_Files_NTU_2023-11-28.zip > BBFL2W-1295.dev
 1295,CC_scale_factor_turbd,0.0493,
 1295,CC_cal_range,"[0,200]",

--- a/calibration/TURBDX/CGINS-TURBDX-01320__20231024.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01320__20231024.csv
@@ -1,0 +1,4 @@
+serial,name,value,notes
+1320,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1320_Calibration_Files_2021-12-29.zip > BBFL2W-1320.dev
+1320,CC_scale_factor_turbd,6.061E-02,
+1320,CC_cal_range,"[0,250]",

--- a/calibration/TURBDX/CGINS-TURBDX-01320__20231024.csv
+++ b/calibration/TURBDX/CGINS-TURBDX-01320__20231024.csv
@@ -1,4 +1,4 @@
 serial,name,value,notes
-1320,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1320_Calibration_Files_2021-12-29.zip > BBFL2W-1320.dev
+1320,CC_dark_counts_turbd,50,source_file FLORT-D_BBFL2W_SN_1320_Calibration_Files_NTU_2023-10-24.zip > BBFL2W-1320.dev
 1320,CC_scale_factor_turbd,6.061E-02,
 1320,CC_cal_range,"[0,250]",


### PR DESCRIPTION
ADCPTQ cal csvs
TURBDX cal csvs (plus 3 of 4 associated FLORTD cal csvs for the NSIF FLORT/TURBD - didn't receive vendor cal docs for the 4th one yet)