### PR TITLE
Cross mio updates for swm prawlers

### DIFF
--- a/bulk/eng_bulk_load-AssetRecord.csv
+++ b/bulk/eng_bulk_load-AssetRecord.csv
@@ -156,6 +156,8 @@ CGCON-BSTC01-01003,OL000338,Sensor,0,Sensor and Telemetry Platform Controller,Se
 CGCON-BSTC01-01015,OL000341,Sensor,0,Sensor and Telemetry Platform Controller,Sensor and Telemetry Controller,WHOI,STC,1015,,,,DELETE?,
 CGCON-BSTC01-14362,OL000346,Sensor,0,Sensor and Telemetry Platform Controller,Sensor and Telemetry Controller,WHOI,STC,21436-2,,,,DELETE?,
 CGCON-BSTC01-23436,OL000334,Sensor,0,Sensor and Telemetry Platform Controller,Sensor and Telemetry Controller,WHOI,STC,23436,,,,DELETE?,
+CGCON-BSWSTC-00001,,Sensor,0,Sensor and Telemetry Platform Controller,Sensor and Telemetry Controller,WHOI,STC,3703-00300-00001-00001,,,,,Woods Hole Oceanographic Institution
+CGCON-BSWSTC-00002,,Sensor,0,Sensor and Telemetry Platform Controller,Sensor and Telemetry Controller,WHOI,STC,3703-00300-00001-00002,,,,,Woods Hole Oceanographic Institution
 CGCON-CSPPCE-00001,,Sensor,0,Coastal Surface Piercing Profiler Controller,,WET Labs,AMP,WLP-001,,,,,Oregon State University
 CGCON-CSPPCE-00002,N00122.1,Sensor,0,Coastal Surface Piercing Profiler Controller,"Profiler, Coastal Surface Piercing",WET Labs,AMP,WLP-002,,20140630,310000,FAS-540601,Oregon State University
 CGCON-CSPPCE-00003,N00123.1,Sensor,0,Coastal Surface Piercing Profiler Controller,"Profiler, Coastal Surface Piercing",WET Labs,AMP,WLP-003,,20140616,310000,FAS-540601,Oregon State University
@@ -167,6 +169,8 @@ CGCON-CSPPCP-00005,N00125.1,Sensor,0,Coastal Surface Piercing Profiler Controlle
 CGCON-CWFPCE-37801,,Sensor,0,Coastal Wire-Following Profiler Controller,WFP COASTAL Electronics #1,McLane,MMP-7,ML14378-01,,20170907,,,Oregon State University
 CGCON-CWFPCE-99103,A00285.1,Sensor,0,Coastal Wire-Following Profiler Controller,WFP COASTAL Electronics #1,McLane,MMP-7,ML12991-03,,20130426,0,,Oregon State University
 CGCON-CWFPCE-99104,A00303.1,Sensor,0,Coastal Wire-Following Profiler Controller,WFP COASTAL Electronics #1,McLane,MMP-7,ML12991-04,,20130510,0,,Oregon State University
+CGCON-CWFPCP-03501,,Sensor,0,Coastal Wire-Following Profiler Controller,Prawler Electronics,McLane,Prawler,ML16035-01,,,,,Woods Hole Oceanographic Institution
+CGCON-CWFPCP-03502,,Sensor,0,Coastal Wire-Following Profiler Controller,Prawler Electronics,McLane,Prawler,ML16035-02,,,,,Woods Hole Oceanographic Institution
 CGCON-CWFPCP-10301,A00846.1,Sensor,0,Coastal Wire-Following Profiler Controller,WFP COASTAL Electronics #1,McLane,MMP-7,ML13103-01,,20140128,0,,Woods Hole Oceanographic Institution
 CGCON-CWFPCP-10302,A00847.1,Sensor,0,Coastal Wire-Following Profiler Controller,WFP COASTAL Electronics #1,McLane,MMP-7,ML13103-02,,20140128,0,,Woods Hole Oceanographic Institution
 CGCON-CWFPCP-10303,A00848.1,Sensor,0,Coastal Wire-Following Profiler Controller,WFP COASTAL Electronics #1,McLane,MMP-7,ML13103-03,,20140129,0,,Woods Hole Oceanographic Institution

--- a/bulk/node_bulk_load-AssetRecord.csv
+++ b/bulk/node_bulk_load-AssetRecord.csv
@@ -67,6 +67,8 @@ CGVEH-CSPPCP-00005,N00125,Node,0,Coastal Surface Piercing Profiler Controller,"P
 CGVEH-CWFPCE-37801,,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,MMP-7,ML14378-01,,20170907,,,Oregon State University
 CGVEH-CWFPCE-99103,A00285,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,MMP-7,ML12991-03,,20130426,92259.49,210-3512,Oregon State University
 CGVEH-CWFPCE-99104,A00303,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,MMP-7,ML12991-04,,20130510,92259.49,210-3512,Oregon State University
+CGVEH-CWFPCP-03501,,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,Prawler,ML16035-01,,,,,Woods Hole Oceanographic Institution
+CGVEH-CWFPCP-03502,,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,Prawler,ML16035-02,,,,,Woods Hole Oceanographic Institution
 CGVEH-CWFPCP-10301,A00846,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,MMP-7,ML13103-01,,20140128,94082,,Woods Hole Oceanographic Institution
 CGVEH-CWFPCP-10302,A00847,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,MMP-7,ML13103-02,,20140128,94082,,Woods Hole Oceanographic Institution
 CGVEH-CWFPCP-10303,A00848,Node,0,Coastal Wire-Following Profiler,WFP COASTAL,McLane,MMP-7,ML13103-03,,20140128,94082,,Woods Hole Oceanographic Institution

--- a/bulk/sensor_bulk_load-AssetRecord.csv
+++ b/bulk/sensor_bulk_load-AssetRecord.csv
@@ -1094,8 +1094,8 @@ CGINS-DOFSTK-03506,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFS
 CGINS-DOFSTK-03523,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML14300-02,Sea-Bird Electronics,SBE 43F,43-3523,,20170627,,,Woods Hole Oceanographic Institution
 CGINS-DOFSTK-03535,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML14378-01,Sea-Bird Electronics,SBE 43F,43-3535,,20170907,,,Oregon State University
 CGINS-DOFSTK-04361,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML14378-01,Sea-Bird Electronics,SBE 43F,43-4361,,20230201,,,Oregon State University
-CGINS-DOFSTP-04320,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series P,DOFST for Prawler,Sea-Bird Electronics,Optode 4831,4320,,,,,Woods Hole Oceanographic Institution
-CGINS-DOFSTP-04321,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series P,DOFST for Prawler,Sea-Bird Electronics,Optode 4831,4321,,,,,Woods Hole Oceanographic Institution
+CGINS-DOFSTP-04320,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series P,DOFST for Prawler,Aanderaa,Optode 4831,4320,,,,,Woods Hole Oceanographic Institution
+CGINS-DOFSTP-04321,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series P,DOFST for Prawler,Aanderaa,Optode 4831,4321,,,,,Woods Hole Oceanographic Institution
 CGINS-DOSTAD-00030,N00323,Sensor,0,Dissolved Oxygen Stable Response bought for Glider deployed on a surface mooring: DOSTA Series D,DOSTA for Slocum Glider,Aanderaa,Optode 4831,30,,20121228,,,
 CGINS-DOSTAD-00100,N00328,Sensor,0,Dissolved Oxygen Stable Response bought for Glider deployed on a surface mooring: DOSTA Series D,DOSTA for Slocum Glider,Aanderaa,Optode 4831,100,,20121228,,,
 CGINS-DOSTAD-00126,A00176,Sensor,0,Dissolved Oxygen Stable Response: DOSTA Series D,DOSTA SERIES D (AADI 4831),Aanderaa,Optode 4831,126,,20130128,5258.25,,Woods Hole Oceanographic Institution

--- a/bulk/sensor_bulk_load-AssetRecord.csv
+++ b/bulk/sensor_bulk_load-AssetRecord.csv
@@ -1074,6 +1074,8 @@ CGINS-CTDPFL-00150,OL000039,Sensor,0,CTD Profiler: CTDPF Series L,CTDPF Series L
 CGINS-CTDPFL-00151,OL000043,Sensor,0,CTD Profiler: CTDPF Series L,CTDPF Series L,Sea-Bird Electronics,SBE 52-MP,151,,,,,
 CGINS-CTDPFL-00152,OL000051,Sensor,0,CTD Profiler: CTDPF Series L,CTDPF Series L,Sea-Bird Electronics,SBE 52-MP,152,,,,,
 CGINS-CTDPFL-00153,OL000055,Sensor,0,CTD Profiler: CTDPF Series L,CTDPF Series L,Sea-Bird Electronics,SBE 52-MP,153,,,,,
+CGINS-CTDPFP-00068,,Sensor,0,CTD Profiler: CTDPF Series P,,Sea-Bird Electronics,SBE 37-SM,709-0068,,,,,Woods Hole Oceanographic Institution
+CGINS-CTDPFP-00070,,Sensor,0,CTD Profiler: CTDPF Series P,,Sea-Bird Electronics,SBE 37-SM,709-0070,,,,,Woods Hole Oceanographic Institution
 CGINS-DOFSTK-00209,N00002,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML12714-01,Sea-Bird Electronics,SBE 43F,43-0209,,20110617,,,Woods Hole Oceanographic Institution
 CGINS-DOFSTK-02397,N00009,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML12936-01,Sea-Bird Electronics,SBE 43F,43-2397,,20130122,,,Woods Hole Oceanographic Institution
 CGINS-DOFSTK-02496,N00051,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML12991-03,Sea-Bird Electronics,SBE 43F,43-2496,,20130426,,,Oregon State University
@@ -1092,6 +1094,8 @@ CGINS-DOFSTK-03506,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFS
 CGINS-DOFSTK-03523,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML14300-02,Sea-Bird Electronics,SBE 43F,43-3523,,20170627,,,Woods Hole Oceanographic Institution
 CGINS-DOFSTK-03535,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML14378-01,Sea-Bird Electronics,SBE 43F,43-3535,,20170907,,,Oregon State University
 CGINS-DOFSTK-04361,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series K,DOFST for WFP Coastal ML14378-01,Sea-Bird Electronics,SBE 43F,43-4361,,20230201,,,Oregon State University
+CGINS-DOFSTP-04320,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series P,DOFST for Prawler,Sea-Bird Electronics,Optode 4831,4320,,,,,Woods Hole Oceanographic Institution
+CGINS-DOFSTP-04321,,Sensor,0,Dissolved Oxygen Fast Response: DOFST Series P,DOFST for Prawler,Sea-Bird Electronics,Optode 4831,4321,,,,,Woods Hole Oceanographic Institution
 CGINS-DOSTAD-00030,N00323,Sensor,0,Dissolved Oxygen Stable Response bought for Glider deployed on a surface mooring: DOSTA Series D,DOSTA for Slocum Glider,Aanderaa,Optode 4831,30,,20121228,,,
 CGINS-DOSTAD-00100,N00328,Sensor,0,Dissolved Oxygen Stable Response bought for Glider deployed on a surface mooring: DOSTA Series D,DOSTA for Slocum Glider,Aanderaa,Optode 4831,100,,20121228,,,
 CGINS-DOSTAD-00126,A00176,Sensor,0,Dissolved Oxygen Stable Response: DOSTA Series D,DOSTA SERIES D (AADI 4831),Aanderaa,Optode 4831,126,,20130128,5258.25,,Woods Hole Oceanographic Institution


### PR DESCRIPTION
Added prawler info to node bulk load, eng bulk load, sensor bulk load.  They are technically WFPs as well so some of that terminology is the same, but I put Prawler where needed to differentiate from MMPs.  And then we realized we needed to differentiate the STC controller UID format from the WFP ones due to same sequential S/Ns being used (starting from -00001 for prawler STCs), so we decided on this format (in eng bulk load): CGCON-BSWSTC-xxxxx

Marine infrastructure Ss should help as reference as well (attached).  And table from WFP spec as well...

This was from Charlie @ McLane re prawler sensor SNs (and confirmed w/ Sheri's checks except for one CTD sensor where SN wasn't visible):
The serial numbers for the sensors are as follows:
16035-01 SBE s/n 709-0070  Aanderaa Optode s/n 4320
16035-02 SBE s/n 709-0068  Aanderaa Optode s/n 4321


[1100-00006_Marine_Infrastructure_Vocabulary_and_Reference_Designators_OOI_2024-03-20_Ver_2-05.xlsx](https://github.com/WHOIGit/ooicgsn-asset-management/files/14950146/1100-00006_Marine_Infrastructure_Vocabulary_and_Reference_Designators_OOI_2024-03-20_Ver_2-05.xlsx)
[3310-00003_Table 5.1.1.pdf](https://github.com/WHOIGit/ooicgsn-asset-management/files/14950173/3310-00003_Table.5.1.1.pdf)



