### PR TITLE
P21 Cruise-specific Cal csvs

### DIFF
--- a/calibration/ADCPSL/CGINS-ADCPSL-18446__20241204.csv
+++ b/calibration/ADCPSL/CGINS-ADCPSL-18446__20241204.csv
@@ -1,0 +1,8 @@
+serial,name,value,notes
+18446,CC_scale_factor1,0.45,constant; CP14NEPM-00002
+18446,CC_scale_factor2,0.45,constant
+18446,CC_scale_factor3,0.45,constant
+18446,CC_scale_factor4,0.45,constant
+18446,CC_bin_size,800,in cm
+18446,CC_dist_first_bin,1662,in cm
+18446,CC_orientation,1,1 is upward looking; 0 is downward looking

--- a/calibration/ADCPSL/CGINS-ADCPSL-21393__20241204.csv
+++ b/calibration/ADCPSL/CGINS-ADCPSL-21393__20241204.csv
@@ -1,0 +1,8 @@
+serial,name,value,notes
+21393,CC_scale_factor1,0.45,constant; CP14SEPM-00002
+21393,CC_scale_factor2,0.45,constant
+21393,CC_scale_factor3,0.45,constant
+21393,CC_scale_factor4,0.45,constant
+21393,CC_bin_size,800,in cm
+21393,CC_dist_first_bin,1662,in cm
+21393,CC_orientation,1,1 is upward looking; 0 is downward looking

--- a/calibration/ADCPTG/CGINS-ADCPTG-18660__20241204.csv
+++ b/calibration/ADCPTG/CGINS-ADCPTG-18660__20241204.csv
@@ -1,0 +1,8 @@
+serial,name,value,notes
+18660,CC_scale_factor1,0.45,constant; CP13NOPM-00002
+18660,CC_scale_factor2,0.45,constant
+18660,CC_scale_factor3,0.45,constant
+18660,CC_scale_factor4,0.45,constant
+18660,CC_bin_size,400,in cm
+18660,CC_dist_first_bin,840,in cm
+18660,CC_orientation,1,1 is upward looking; 0 is downward looking

--- a/calibration/ADCPTG/CGINS-ADCPTG-20495__20241204.csv
+++ b/calibration/ADCPTG/CGINS-ADCPTG-20495__20241204.csv
@@ -1,0 +1,8 @@
+serial,name,value,notes
+20495,CC_scale_factor1,0.45,constant; CP13EAPM-00002
+20495,CC_scale_factor2,0.45,constant
+20495,CC_scale_factor3,0.45,constant
+20495,CC_scale_factor4,0.45,constant
+20495,CC_bin_size,400,in cm
+20495,CC_dist_first_bin,840,in cm
+20495,CC_orientation,1,1 is upward looking; 0 is downward looking

--- a/calibration/ADCPTG/CGINS-ADCPTG-20499__20241204.csv
+++ b/calibration/ADCPTG/CGINS-ADCPTG-20499__20241204.csv
@@ -1,0 +1,8 @@
+serial,name,value,notes
+20499,CC_scale_factor1,0.45,constant; CP13SOPM-00002
+20499,CC_scale_factor2,0.45,constant
+20499,CC_scale_factor3,0.45,constant
+20499,CC_scale_factor4,0.45,constant
+20499,CC_bin_size,400,in cm
+20499,CC_dist_first_bin,840,in cm
+20499,CC_orientation,1,1 is upward looking; 0 is downward looking

--- a/calibration/METBKA/CGINS-METLGR-00017__20241204.csv
+++ b/calibration/METBKA/CGINS-METLGR-00017__20241204.csv
@@ -1,0 +1,9 @@
+serial,name,value,notes
+LGR017,CC_depth_of_conductivity_and_temperature_measurements_m,0.98,CP10CNSM-00002 METBK1
+LGR017,CC_height_of_air_humidity_measurement_m,4.255,
+LGR017,CC_height_of_air_temperature_measurement_m,4.255,
+LGR017,CC_height_of_windspeed_sensor_above_sealevel_m,4.74,
+LGR017,CC_jcool,1,Constant
+LGR017,CC_jwarm,1,Constant
+LGR017,CC_zinvpbl,600,Constant
+LGR017,CC_use_velpt,1,Constant

--- a/calibration/METBKA/CGINS-METLGR-00037__20241204.csv
+++ b/calibration/METBKA/CGINS-METLGR-00037__20241204.csv
@@ -1,0 +1,9 @@
+serial,name,value,notes
+LGR037,CC_depth_of_conductivity_and_temperature_measurements_m,1.11,CP10CNSM-00002 METBK2
+LGR037,CC_height_of_air_humidity_measurement_m,4.255,
+LGR037,CC_height_of_air_temperature_measurement_m,4.255,
+LGR037,CC_height_of_windspeed_sensor_above_sealevel_m,4.74,
+LGR037,CC_jcool,1,Constant
+LGR037,CC_jwarm,1,Constant
+LGR037,CC_zinvpbl,600,Constant
+LGR037,CC_use_velpt,1,Constant


### PR DESCRIPTION
Profiler Mooring ADCP cal csvs
Surface Mooring METLGR cal csvs

References:
mooring configs in Pioneer 21 folder in Vault
METBK_Module_Heights.xlsx in Sensors Notebook/METBK in Vault (same as NES)
3408-00201 cal csv procedure
