### PR TITLE
new prawler FLORTP cal csv

### DIFF
--- a/calibration/FLORTP/CGINS-FLORTP-08570__20231024.csv
+++ b/calibration/FLORTP/CGINS-FLORTP-08570__20231024.csv
@@ -1,0 +1,11 @@
+serial,name,value,notes
+8570,CC_angular_resolution,1.076,Constant; source_file FLORT-P_BBFL2W_SN_8570_Calibration_2023-10-24.zip > BBFL2W-8570.dev
+8570,CC_dark_counts_cdom,49,
+8570,CC_dark_counts_chlorophyll_a,46,
+8570,CC_dark_counts_volume_scatter,47.125,
+8570,CC_depolarization_ratio,0.039,Constant
+8570,CC_measurement_wavelength,700,Constant
+8570,CC_scale_factor_cdom,9.077E-02,
+8570,CC_scale_factor_chlorophyll_a,7.256E-03,
+8570,CC_scale_factor_volume_scatter,1.663E-06,
+8570,CC_scattering_angle,124,Constant


### PR DESCRIPTION
created FLORTP cal csv for the prawler that was for 'winter' Pioneer - per discussion w/ Andrew, used the FLORTD cal csv format for cal coeff and constants.
Prawler 16035-05 - cal files are in Platform_Records/Prawlers/16035-05 in Vault.