### PR TITLE
Cross-mio updates

### DIFF
--- a/bulk/eng_bulk_load-AssetRecord.csv
+++ b/bulk/eng_bulk_load-AssetRecord.csv
@@ -237,6 +237,7 @@ CGCON-GLDRCP-00559,,Sensor,1,Mobile Asset Controller for Coastal Glider,GL559 Co
 CGCON-GLDRCP-00564,,Sensor,1,Mobile Asset Controller for Coastal Glider,GL564 Controller,Teledyne Webb,G2 Slocum Gliders,564,,,,Was Global; now Coastal,Woods Hole Oceanographic Institution
 CGCON-GLDRCP-00583,,Sensor,1,Mobile Asset Controller for Coastal Glider,GL583 Controller,Teledyne Webb,G2 Slocum Gliders,583,,,,Was Global; now Coastal,Woods Hole Oceanographic Institution
 CGCON-GLDRCP-00913,,Sensor,1,Mobile Asset Controller for Coastal Glider,GL913 Controller,Teledyne Webb,G3 Slocum Gliders,913,,,,,Woods Hole Oceanographic Institution
+CGCON-GLDRCP-01145,,Sensor,1,Mobile Asset Controller for Coastal Glider,G1145 Controller,Teledyne Webb,G3 Slocum Gliders,1145,,,,,Woods Hole Oceanographic Institution
 CGCON-GLDRGP-00514,OL000133,Sensor,1,Mobile Asset Controller for Profiling Glider,PG514 Controller,Teledyne Webb,G2 Slocum Gliders,514,,,,,Woods Hole Oceanographic Institution
 CGCON-GLDRGP-00515,OL000134,Sensor,1,Mobile Asset Controller for Profiling Glider,PG515 Controller,Teledyne Webb,G2 Slocum Gliders,515,,,,,Woods Hole Oceanographic Institution
 CGCON-GLDRGP-00528,OL000122,Sensor,1,Mobile Asset Controller for Profiling Glider,PG528 Controller,Teledyne Webb,G2 Slocum Gliders,528,,,,,Woods Hole Oceanographic Institution

--- a/bulk/node_bulk_load-AssetRecord.csv
+++ b/bulk/node_bulk_load-AssetRecord.csv
@@ -121,6 +121,7 @@ CGVEH-GLDRCP-00559,,Node,1,Coastal Glider 559,COASTAL GLIDER 1000M,Teledyne Webb
 CGVEH-GLDRCP-00564,,Node,1,Coastal Profiling Glider 564,COASTAL GLIDER 200M,Teledyne Webb,ASSY 302392-3,564,,,,,Woods Hole Oceanographic Institution
 CGVEH-GLDRCP-00583,,Node,1,Coastal Profiling Glider 583,COASTAL GLIDER 200M,Teledyne Webb,ASSY 302392-3,583,,,,,Woods Hole Oceanographic Institution
 CGVEH-GLDRCP-00913,,Node,1,Coastal Glider 913,COASTAL GLIDER 1000M,Teledyne Webb,ASSY GLD-0089-D,913,,,,,Woods Hole Oceanographic Institution
+CGVEH-GLDRCP-01145,,Node,1,Coastal Glider 1145,COASTAL GLIDER 1000M,Teledyne Webb,ASSY GLD-0089-D,1145,,,,,Woods Hole Oceanographic Institution
 CGVEH-GLDRGP-00514,A01222,Node,1,Profiling Glider 514,GLIDER GLOBAL PROFILING,Teledyne Webb,ASSY 302392-3,514,,20141223,256823.5,,Woods Hole Oceanographic Institution
 CGVEH-GLDRGP-00515,A01223,Node,1,Profiling Glider 515,GLIDER GLOBAL PROFILING,Teledyne Webb,ASSY 302392-3,515,,20141223,228847.5,,Woods Hole Oceanographic Institution
 CGVEH-GLDRGP-00528,A01667,Node,1,Profiling Glider 528,GLIDER GLOBAL PROFILING,Teledyne Webb,ASSY 302393-3,528,,20150803,256200.6,,Woods Hole Oceanographic Institution

--- a/bulk/sensor_bulk_load-AssetRecord.csv
+++ b/bulk/sensor_bulk_load-AssetRecord.csv
@@ -1793,6 +1793,7 @@ CGINS-METHRH-00298,A01881,Sensor,0,Bulk Meteorology Instrument Package: METBK HR
 CGINS-METHRH-00360,A01718,Sensor,0,Bulk Meteorology Instrument Package: METBK HRH Module,METBK HRH MODULE,Star Engineering,ABS102-HRH,HRH360,,20150817,8050,,
 CGINS-METHRH-00361,A01719,Sensor,0,Bulk Meteorology Instrument Package: METBK HRH Module,METBK HRH MODULE,Star Engineering,ABS102-HRH,HRH361,,20150817,8050,,
 CGINS-METHRH-00362,A02136,Sensor,0,Bulk Meteorology Instrument Package: METBK HRH Module,METBK HRH MODULE,Star Engineering,ABS102-HRH,HRH362,,,,,Woods Hole Oceanographic Institution
+CGINS-METHRH-00506,,Sensor,0,Bulk Meteorology Instrument Package: METBK HRH Module,METBK HRH MODULE,Star Engineering,ABS102-HRH,HRH506,,,,,on loan from UOP for comparison test
 CGINS-METLGR-00001,N00745,Sensor,0,Bulk Meteorology Instrument Package: METBK LGR Module,METBK LGR MODULE,Star Engineering,ASIMET,LGR001,,,,Destroyed on CP01CNSM-00001,Woods Hole Oceanographic Institution
 CGINS-METLGR-00002,N00746,Sensor,0,Bulk Meteorology Instrument Package: METBK LGR Module,METBK LGR MODULE,Star Engineering,ASIMET,LGR002,,,,Destroyed on CP01CNSM-00001,Woods Hole Oceanographic Institution
 CGINS-METLGR-00003,N00739,Sensor,0,Bulk Meteorology Instrument Package: METBK LGR Module,METBK LGR MODULE,Star Engineering,ASIMET,LGR003,,,,,Woods Hole Oceanographic Institution

--- a/vocab/vocab.csv
+++ b/vocab/vocab.csv
@@ -658,13 +658,13 @@ CP03ISPM-RII01-02-ADCPTG010,Coastal Pioneer NES,Inshore Profiler Mooring,Mooring
 CP03ISPM-SBS01,Coastal Pioneer NES,Inshore Profiler Mooring,Surface Buoy,,,,0,0
 CP03ISPM-SBS01-00-STCENG000,Coastal Pioneer NES,Inshore Profiler Mooring,Surface Buoy,Platform Controller,WHOI,Sensor and Telemetry Controller,0,0
 CP03ISPM-SBS01-01-MOPAK0000,Coastal Pioneer NES,Inshore Profiler Mooring,Surface Buoy,3-Axis Motion Pack,MicroStrain,3DM-GX3-25,0,0
-CP03ISPM-WFP01,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,,,,70,70
-CP03ISPM-WFP01-00-WFPENG000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,Profiler Controller,McLane,MMP,70,70
-CP03ISPM-WFP01-01-VEL3DK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,3-D Single Point Velocity Meter,Nortek,Aquadopp II,70,70
-CP03ISPM-WFP01-02-DOFSTK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,Dissolved Oxygen,Sea-Bird,SBE 43F,70,70
-CP03ISPM-WFP01-03-CTDPFK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,CTD,Sea-Bird,SBE 52MP,70,70
-CP03ISPM-WFP01-04-FLORTK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,3-Wavelength Fluorometer,WET Labs,ECO Triplet,70,70
-CP03ISPM-WFP01-05-PARADK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,Photosynthetically Available Radiation,Biospherical Instruments,QSP-2200,70,70
+CP03ISPM-WFP01,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,,,,15,70
+CP03ISPM-WFP01-00-WFPENG000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,Profiler Controller,McLane,MMP,15,70
+CP03ISPM-WFP01-01-VEL3DK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,3-D Single Point Velocity Meter,Nortek,Aquadopp II,15,70
+CP03ISPM-WFP01-02-DOFSTK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,Dissolved Oxygen,Sea-Bird,SBE 43F,15,70
+CP03ISPM-WFP01-03-CTDPFK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,CTD,Sea-Bird,SBE 52MP,15,70
+CP03ISPM-WFP01-04-FLORTK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,3-Wavelength Fluorometer,WET Labs,ECO Triplet,15,70
+CP03ISPM-WFP01-05-PARADK000,Coastal Pioneer NES,Inshore Profiler Mooring,Wire-Following Profiler,Photosynthetically Available Radiation,Biospherical Instruments,QSP-2200,15,70
 CP03ISSM,Coastal Pioneer NES,Inshore Surface Mooring,,,,,0,92
 CP03ISSM-MFC31,Coastal Pioneer NES,Inshore Surface Mooring,Seafloor Multi-Function Node (MFN),,,,91.5,91.5
 CP03ISSM-MFC31-00-CPMENG000,Coastal Pioneer NES,Inshore Surface Mooring,Seafloor Multi-Function Node (MFN),Platform Controller,WHOI,Communications and Power Manager,91.5,91.5
@@ -1225,6 +1225,13 @@ CP15MOAS-G0913-02-FLORTM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 913
 CP15MOAS-G0913-03-CTDGVM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 913,CTD,Sea-Bird,SBE Glider Payload CTD (GP-CTD),0,1000
 CP15MOAS-G0913-04-DOSTAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 913,Dissolved Oxygen,Aanderaa,Optode 4831,0,1000
 CP15MOAS-G0913-05-PARADM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 913,Photosynthetically Available Radiation,Biospherical Instruments,QSP-2155,0,1000
+CP15MOAS-G1145,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,,,,0,1000
+CP15MOAS-G1145-00-ENG000000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,Mobile Asset Controller,Teledyne Webb,G3 Slocum Gliders,0,1000
+CP15MOAS-G1145-01-ADCPAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,Velocity Profiler (600kHz),Teledyne RDI,Explorer DVL 600 kHz,0,1000
+CP15MOAS-G1145-02-FLORTM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,3-Wavelength Fluorometer,WET Labs,ECO Puck FLBBCD-SLC,0,1000
+CP15MOAS-G1145-03-CTDGVM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,CTD,Sea-Bird,SBE Glider Payload CTD (GP-CTD),0,1000
+CP15MOAS-G1145-04-DOSTAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,Dissolved Oxygen,Aanderaa,Optode 4831,0,1000
+CP15MOAS-G1145-05-PARADM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 1145,Photosynthetically Available Radiation,Biospherical Instruments,QSP-2155,0,1000
 CP15MOAS-GL335,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 335,,,,0,200
 CP15MOAS-GL335-00-ENG000000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 335,Mobile Asset Controller,Teledyne Webb,G2 Slocum Gliders,0,200
 CP15MOAS-GL335-01-ADCPAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 335,Velocity Profiler (600kHz),Teledyne RDI,Explorer DVL 600 kHz,0,200
@@ -1239,6 +1246,13 @@ CP15MOAS-GL339-02-FLORTM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 339
 CP15MOAS-GL339-03-CTDGVM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 339,CTD,Sea-Bird,SBE Glider Payload CTD (GP-CTD),0,200
 CP15MOAS-GL339-04-DOSTAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 339,Dissolved Oxygen,Aanderaa,Optode 4831,0,200
 CP15MOAS-GL339-05-PARADM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 339,Photosynthetically Available Radiation,Biospherical Instruments,QSP-2155,0,200
+CP15MOAS-GL376,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,,,,0,1000
+CP15MOAS-GL376-00-ENG000000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,Mobile Asset Controller,Teledyne Webb,G2 Slocum Gliders,0,1000
+CP15MOAS-GL376-01-ADCPAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,Velocity Profiler (600kHz),Teledyne RDI,Explorer DVL 600 kHz,0,1000
+CP15MOAS-GL376-02-FLORTM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,3-Wavelength Fluorometer,WET Labs,ECO Puck FLBBCD-SLK,0,1000
+CP15MOAS-GL376-03-CTDGVM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,CTD,Sea-Bird,SBE Glider Payload CTD (GP-CTD),0,1000
+CP15MOAS-GL376-04-DOSTAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,Dissolved Oxygen,Aanderaa,Optode 4831,0,1000
+CP15MOAS-GL376-05-PARADM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 376,Photosynthetically Available Radiation,Biospherical Instruments,QSP-2155,0,1000
 CP15MOAS-GL379,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 379,,,,0,1000
 CP15MOAS-GL379-00-ENG000000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 379,Mobile Asset Controller,Teledyne Webb,G2 Slocum Gliders,0,1000
 CP15MOAS-GL379-01-ADCPAM000,Coastal Pioneer MAB,Mobile Assets,Coastal Glider 379,Velocity Profiler (600kHz),Teledyne RDI,Explorer DVL 600 kHz,0,1000


### PR DESCRIPTION
Updates in prep for Pioneer 21, plus a general update to vocab:

- Vocab.csv - added new MAB gliders G1145 and GL376. Per Collin - 1145 is same as G0913, and 376 is same as GL379.
- Vocab.csv - corrected min depth on lines 661 through 667 per Stace's request (from 70 to 15).
- Node bulk load - added CGVEH-GLDRCP-01145
- Eng bulk load - added CGCON-GLDRCP-01145
- Sensor bulk load - added loaner CGINS-METHRH-00506 (on loan from UOP for test)